### PR TITLE
Fix github URL in plugin README

### DIFF
--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -13,7 +13,7 @@ Author: {{ cookiecutter.full_name }}
 
 Clone the project:
 
-    git clone https://{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}
+    git clone https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}
     cd {{ cookiecutter.repo_name }}
     mkdir build
     cd build


### PR DESCRIPTION
The README template contains an interpolated string used to output the github
URL of the plugin. However, using the variables currently provided by the
cookiecutter script as intended omits the host part of the URL.
This has now been updated.